### PR TITLE
test change actions from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -   name: Checkout Code
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
       -   name: Setup Java17
-          uses: actions/setup-java@v3
+          uses: actions/setup-java@v4
           with:
             java-version: '17'
             distribution: 'zulu'
@@ -25,9 +25,9 @@ jobs:
       - linter
     steps:
       -   name: Checkout Code
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
       -   name: Setup Java17
-          uses: actions/setup-java@v3
+          uses: actions/setup-java@v4
           with:
             java-version: '17'
             distribution: 'zulu'
@@ -42,9 +42,9 @@ jobs:
       - unit-test
     steps:
       -   name: Checkout Code
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
       -   name: Setup Java17
-          uses: actions/setup-java@v3
+          uses: actions/setup-java@v4
           with:
             java-version: '17'
             distribution: 'zulu'


### PR DESCRIPTION
test github action by chaning v3 to v4 (try to remove deprecated warning)